### PR TITLE
FIX: resolve __dirname to expand paths

### DIFF
--- a/mod_server/src/MedAttention.ts
+++ b/mod_server/src/MedAttention.ts
@@ -20,7 +20,7 @@ class healer implements IMod
 {
 	private pkg;
 	private path = require('path');
-    private modName = this.path.basename(this.path.dirname(__dirname.split('/').pop()));
+	private modName = this.path.basename(this.path.dirname(this.path.resolve(__dirname)));
 
 	public postDBLoad(container: DependencyContainer): void {
 		const logger = container.resolve<ILogger>("WinstonLogger");


### PR DESCRIPTION
Running on Linux this error comes up because `__dirname` is just `.` (current working directory). 

`Error: ENOENT: no such file or directory, scandir 'user/mods/./database/'`

This updates to use the `path` module to expand short names such as `.`, `~`, and so on.

I have made the change and tested and it works on Linux. I don't have windows so I can't verify, but given that this uses the stdlib I can't imagine it won't work. LMK if you have some tests or something I can update to verify.