### PR TITLE
Changed var name in patched method to match var name of original method

### DIFF
--- a/mod_client/MedicalAttention/Utilities/patchMeds.cs
+++ b/mod_client/MedicalAttention/Utilities/patchMeds.cs
@@ -13,9 +13,9 @@ namespace MedicalAttention.Utilities
         }
 
         [PatchPrefix]
-        static bool Prefix(EPhysicalCondition medCheck, ref bool __result)
+        static bool Prefix(EPhysicalCondition c, ref bool __result)
         {
-            if (medCheck == EPhysicalCondition.UsingMeds && MedsPlugin.sprintWithMeds.Value)
+            if (c == EPhysicalCondition.UsingMeds && MedsPlugin.sprintWithMeds.Value)
             {
                 __result = false;
                 return false;

--- a/mod_client/MedicalAttention/Utilities/patchSurgeries.cs
+++ b/mod_client/MedicalAttention/Utilities/patchSurgeries.cs
@@ -13,9 +13,9 @@ namespace MedicalAttention.Utilities
         }
 
         [PatchPrefix]
-        static bool Prefix(EPhysicalCondition surgCheck, ref bool __result)
+        static bool Prefix(EPhysicalCondition c, ref bool __result)
         {
-            if (surgCheck == EPhysicalCondition.HealingLegs && MedsPlugin.dontStopForSurgery.Value)
+            if (c == EPhysicalCondition.HealingLegs && MedsPlugin.dontStopForSurgery.Value)
             {
                 __result = false;
                 return false;


### PR DESCRIPTION
Trying to load this mod I got the following error:

`[Info   :   BepInEx] Loading [MedicalAttention 310.0.1]`
`[Error  :  HarmonyX] Failed to patch bool EFT.MovementContext::SetPhysicalCondition(EFT.EPhysicalCondition c, bool val): System.Exception: Parameter "medCheck" not found in method bool EFT.MovementContext::SetPhysicalCondition(EFT.EPhysicalCondition c, bool val)`

Because of this error, the configs inside the F12 Menu where not respected.

Looking at the source code and only changing the variable names inside the patch from "medCheck" and "surgCheck" to "c", I was able to load and use these settings correctly.